### PR TITLE
Module `SAPART`

### DIFF
--- a/apps/flex-web-app/src/modules/part/command.ts
+++ b/apps/flex-web-app/src/modules/part/command.ts
@@ -22,3 +22,11 @@ export class PartCommand implements CommandInterface<"PART"> {
 		this.store.emit("PART", payload);
 	}
 }
+
+export class SapartCommand implements CommandInterface<"SAPART"> {
+	constructor(private store: ChatStore) {}
+
+	send(payload: Command<"SAPART">): void {
+		this.store.emit("SAPART", payload);
+	}
+}

--- a/apps/flex-web-app/src/modules/part/module.ts
+++ b/apps/flex-web-app/src/modules/part/module.ts
@@ -11,7 +11,7 @@
 import { ChatStore } from "~/store/ChatStore";
 
 import { Module } from "../interface";
-import { PartCommand } from "./command";
+import { PartCommand, SapartCommand } from "./command";
 import { PartHandler } from "./handler";
 
 // -------------- //
@@ -55,4 +55,39 @@ export class PartModule implements Module<PartModule> {
 	listen() {
 		this.handler.listen();
 	}
+}
+
+export class SapartModule implements Module<SapartModule> {
+	// ------ //
+	// STATIC //
+	// ------ //
+
+	static NAME = "SAPART";
+
+	static create(store: ChatStore): SapartModule {
+		return new SapartModule(new SapartCommand(store));
+	}
+
+	// ----------- //
+	// Constructor //
+	// ----------- //
+	constructor(private command: SapartCommand) {}
+
+	// ------- //
+	// Méthode //
+	// ------- //
+
+	input(nicknamesRaw?: string, channelsRaw?: string, ...messages: Array<string>) {
+		const nicknames = nicknamesRaw?.split(",");
+		const channels = channelsRaw?.split(",");
+		if (!nicknames || !channels) return;
+		const message = messages.join(" ");
+		this.send({ nicknames, channels, message });
+	}
+
+	send(payload: Command<"SAPART">) {
+		this.command.send(payload);
+	}
+
+	listen() {}
 }

--- a/apps/flex-web-app/src/modules/part/socket.d.ts
+++ b/apps/flex-web-app/src/modules/part/socket.d.ts
@@ -22,6 +22,7 @@ declare interface SapartFormData {
 declare interface PartDataResponse {
 	channel: string;
 	message: string | null;
+	forced_by: string | null;
 }
 
 declare interface Commands {

--- a/apps/flex-web-app/src/modules/part/socket.d.ts
+++ b/apps/flex-web-app/src/modules/part/socket.d.ts
@@ -13,6 +13,12 @@ declare interface PartFormData {
 	message?: string;
 }
 
+declare interface SapartFormData {
+	channels: Array<string>;
+	nicknames: Array<string>;
+	message?: string;
+}
+
 declare interface PartDataResponse {
 	channel: string;
 	message: string | null;
@@ -20,6 +26,7 @@ declare interface PartDataResponse {
 
 declare interface Commands {
 	PART: PartFormData;
+	SAPART: SapartFormData;
 }
 
 declare interface CommandResponsesFromServer {

--- a/apps/flex-web-app/src/store/ChatStore.ts
+++ b/apps/flex-web-app/src/store/ChatStore.ts
@@ -49,7 +49,7 @@ import {
 import { ModeModule } from "~/modules/mode/module";
 import { NickModule } from "~/modules/nick/module";
 import { OperModule } from "~/modules/oper/module";
-import { PartModule } from "~/modules/part/module";
+import { PartModule, SapartModule } from "~/modules/part/module";
 import { PrivmsgModule } from "~/modules/privmsg/module";
 import { QuitModule } from "~/modules/quit/module";
 import { TopicModule } from "~/modules/topic/module";
@@ -106,19 +106,22 @@ export class ChatStore {
 			.add(new ErrorUsernotinchannelHandler(self));
 
 		self.modules.set(AwayModule.NAME, AwayModule.create(self));
-		self.modules.set(IgnoreModule.NAME, IgnoreModule.create(self));
+		self.modules
+			.set(IgnoreModule.NAME, IgnoreModule.create(self))
+			.set(UnignoreModule.NAME, UnignoreModule.create(self));
 		self.modules
 			.set(JoinModule.NAME, JoinModule.create(self))
 			.set(SajoinModule.NAME, SajoinModule.create(self));
 		self.modules.set(KickModule.NAME, KickModule.create(self));
 		self.modules.set(ModeModule.NAME, ModeModule.create(self));
 		self.modules.set(NickModule.NAME, NickModule.create(self));
-		self.modules.set(PartModule.NAME, PartModule.create(self));
+		self.modules
+			.set(PartModule.NAME, PartModule.create(self))
+			.set(SapartModule.NAME, SapartModule.create(self));
 		self.modules.set(PrivmsgModule.NAME, PrivmsgModule.create(self));
 		self.modules.set(OperModule.NAME, OperModule.create(self));
 		self.modules.set(QuitModule.NAME, QuitModule.create(self));
 		self.modules.set(TopicModule.NAME, TopicModule.create(self));
-		self.modules.set(UnignoreModule.NAME, UnignoreModule.create(self));
 
 		/** Channel access level */
 		self.modules

--- a/apps/flex-web-app/sys/room-events/RoomEventPart.vue
+++ b/apps/flex-web-app/sys/room-events/RoomEventPart.vue
@@ -16,11 +16,18 @@ const hostname = computeHostname(props.data.origin);
 		{{ time.formattedTime }}
 	</time>
 	<p>
-		* Parts: <span>{{ data.origin.nickname }}</span> (<span>{{
+		* Parts: <bdo>{{ data.origin.nickname }}</bdo> (<bdo>{{
 			data.origin.ident
-		}}</span
+		}}</bdo
 		>@<span>{{ hostname }}</span
-		>) <em v-if="data.message">(<span>{{ data.message }}</span>)</em>
+		>)
+		<em v-if="data.message">
+			(<output>{{ data.message }}</output>
+			<em v-if="data.forced_by">
+				(Par <bdo>{{ data.forced_by }}</bdo
+				>)</em
+			>)
+		</em>
 	</p>
 </template>
 
@@ -31,7 +38,20 @@ p {
 	color: var(--color-grey500);
 }
 
+bdo,
+output,
 span {
 	color: var(--default-text-color);
+}
+
+output {
+	&::before {
+		content: "« ";
+		color: var(--color-grey400);
+	}
+	&::after {
+		content: " »";
+		color: var(--color-grey400);
+	}
 }
 </style>

--- a/www/flex-ws-server/src/chat/components/client/socket.rs
+++ b/www/flex-ws-server/src/chat/components/client/socket.rs
@@ -254,7 +254,7 @@ impl<'a> Socket<'a>
 	}
 
 	/// Émet au client les réponses liées à la commande /PART.
-	pub fn emit_part(&self, channel: &str, message: Option<&str>)
+	pub fn emit_part(&self, channel: &str, message: Option<&str>, forced_by: Option<&str>)
 	{
 		use crate::src::chat::features::PartCommandResponse;
 
@@ -264,6 +264,7 @@ impl<'a> Socket<'a>
 			origin: &origin,
 			channel,
 			message,
+			forced_by,
 			tags: PartCommandResponse::default_tags(),
 		};
 

--- a/www/flex-ws-server/src/chat/feature.rs
+++ b/www/flex-ws-server/src/chat/feature.rs
@@ -64,6 +64,7 @@ impl Feature for ChatApplication
 				socket.on(OperHandler::COMMAND_NAME, OperHandler::handle);
 				socket.on(QuitHandler::COMMAND_NAME, QuitHandler::handle);
 				socket.on(SajoinHandler::COMMAND_NAME, SajoinHandler::handle);
+				socket.on(SapartHandler::COMMAND_NAME, SapartHandler::handle);
 				socket.on(TopicHandler::COMMAND_NAME, TopicHandler::handle);
 				socket.on(UnignoreHandler::COMMAND_NAME, UnignoreHandler::handle);
 

--- a/www/flex-ws-server/src/chat/features/join/formdata.rs
+++ b/www/flex-ws-server/src/chat/features/join/formdata.rs
@@ -11,7 +11,7 @@
 use flex_web_framework::types::secret;
 
 use crate::command_formdata;
-use crate::macro_rules::command_formdata::validate_channels;
+use crate::macro_rules::command_formdata::{validate_channels, validate_nicknames};
 
 command_formdata! {
 	struct JOIN
@@ -29,6 +29,7 @@ command_formdata! {
 	struct SAJOIN
 	{
 		/// Les pseudos à forcer à rejoindre les salons.
+		#[serde(deserialize_with = "validate_nicknames")]
 		nicknames: Vec<String>,
 		/// Les salons à rejoindre.
 		#[serde(deserialize_with = "validate_channels")]

--- a/www/flex-ws-server/src/chat/features/part/formdata.rs
+++ b/www/flex-ws-server/src/chat/features/part/formdata.rs
@@ -9,11 +9,25 @@
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 use crate::command_formdata;
-use crate::macro_rules::command_formdata::validate_channels;
+use crate::macro_rules::command_formdata::{validate_channels, validate_nicknames};
 
 command_formdata! {
 	struct PART
 	{
+		/// Salons à quitter.
+		#[serde(deserialize_with = "validate_channels")]
+		channels: Vec<String>,
+		/// Message part du client.
+		message: Option<String>,
+	}
+}
+
+command_formdata! {
+	struct SAPART
+	{
+		/// Les pseudo à forcer de quitter les salons.
+		#[serde(deserialize_with = "validate_nicknames")]
+		nicknames: Vec<String>,
 		/// Salons à quitter.
 		#[serde(deserialize_with = "validate_channels")]
 		channels: Vec<String>,

--- a/www/flex-ws-server/src/chat/features/part/response.rs
+++ b/www/flex-ws-server/src/chat/features/part/response.rs
@@ -17,7 +17,7 @@ command_response! {
 		channel: &'a str,
 		/// Raison du message.
 		message: Option<&'a str>,
-		/// Est-ce que l'utilisateur a été forcé de quitter le salon.
+		/// Par qui l'utilisateur a été forcé de quitter le salon.
 		forced_by: Option<&'a str>,
 	}
 }

--- a/www/flex-ws-server/src/chat/features/part/response.rs
+++ b/www/flex-ws-server/src/chat/features/part/response.rs
@@ -17,5 +17,7 @@ command_response! {
 		channel: &'a str,
 		/// Raison du message.
 		message: Option<&'a str>,
+		/// Est-ce que l'utilisateur a été forcé de quitter le salon.
+		forced_by: Option<&'a str>,
 	}
 }

--- a/www/flex-ws-server/src/chat/sessions/channel.rs
+++ b/www/flex-ws-server/src/chat/sessions/channel.rs
@@ -389,16 +389,16 @@ impl ChatApplication
 
 		for channel_room in client_socket.channels_rooms() {
 			let channel_name = &channel_room[8..];
-			client_socket.emit_part(channel_name, Some("/partall"));
+			client_socket.emit_part(channel_name, Some("/partall"), None);
 		}
 	}
 
-	/// Part d'un salon
-	pub fn part_channel(
+	fn internal_part_channel(
 		&self,
 		client_socket: &client::Socket,
 		channel_name: channel::ChannelIDRef,
 		message: Option<&str>,
+		forced: Option<&str>,
 	)
 	{
 		if !self.channels.has(channel_name) {
@@ -416,7 +416,35 @@ impl ChatApplication
 		self.clients
 			.remove_channel(client_socket.cid(), channel_name);
 
-		client_socket.emit_part(channel_name, message)
+		client_socket.emit_part(channel_name, message, forced)
+	}
+
+	/// Part d'un salon
+	pub fn part_channel(
+		&self,
+		client_socket: &client::Socket,
+		channel_name: channel::ChannelIDRef,
+		message: Option<&str>,
+	)
+	{
+		self.internal_part_channel(client_socket, channel_name, message, None)
+	}
+
+	/// Force un utilisateur à quitter un salon.
+	pub fn force_part_channel(
+		&self,
+		client_socket: &client::Socket,
+		force_to_part: &client::Socket,
+		channel_name: channel::ChannelIDRef,
+		message: Option<&str>,
+	)
+	{
+		self.internal_part_channel(
+			force_to_part,
+			channel_name,
+			message,
+			Some(&client_socket.user().nickname),
+		)
 	}
 
 	/// Met à jour les niveaux d'accès d'un client sur un salon.


### PR DESCRIPTION
- feat(web): prise en charge du module `SAPART` (UI)
- feat(web): prise en charge du module `SAPART` (server)
- refactor(web): ajustement du composant d'événement `PART`
