### PR TITLE
Drapeau utilisateur `q` (`NoKick`)

### DIFF
--- a/apps/flex-web-app/src/modules/kick/handler.ts
+++ b/apps/flex-web-app/src/modules/kick/handler.ts
@@ -55,3 +55,25 @@ export class KickHandler implements SocketEventInterface<"KICK"> {
 		this.store.removeChannelForUser(data.channel, data.knick.id);
 	}
 }
+
+export class ErrorCannotkickglobopsHandler
+	implements SocketEventInterface<"ERR_CANNOTKICKGLOBOPS">
+{
+	// ----------- //
+	// Constructor //
+	// ----------- //
+	constructor(private store: ChatStore) {}
+
+	// ------- //
+	// Méthode //
+	// ------- //
+
+	listen() {
+		this.store.on("ERR_CANNOTKICKGLOBOPS", (data) => this.handle(data));
+	}
+
+	handle(data: GenericReply<"ERR_CANNOTKICKGLOBOPS">): void {
+		const room = this.store.roomManager().active();
+		room.addEvent("error:err_cannotkickglobops", { ...data, isMe: true }, data.reason);
+	}
+}

--- a/apps/flex-web-app/src/modules/kick/module.ts
+++ b/apps/flex-web-app/src/modules/kick/module.ts
@@ -12,7 +12,7 @@ import { ChatStore } from "~/store/ChatStore";
 
 import { Module } from "../interface";
 import { KickCommand } from "./command";
-import { KickHandler } from "./handler";
+import { ErrorCannotkickglobopsHandler, KickHandler } from "./handler";
 
 // -------------- //
 // Implémentation //
@@ -26,7 +26,11 @@ export class KickModule implements Module<KickModule> {
 	static NAME = "KICK";
 
 	static create(store: ChatStore): KickModule {
-		return new KickModule(new KickCommand(store), new KickHandler(store));
+		return new KickModule(
+			new KickCommand(store),
+			new KickHandler(store),
+			new ErrorCannotkickglobopsHandler(store),
+		);
 	}
 
 	// ----------- //
@@ -35,6 +39,7 @@ export class KickModule implements Module<KickModule> {
 	constructor(
 		private command: KickCommand,
 		private handler: KickHandler,
+		private numericCannotkickglobopsHandler: ErrorCannotkickglobopsHandler,
 	) {}
 
 	// ------- //
@@ -55,5 +60,6 @@ export class KickModule implements Module<KickModule> {
 
 	listen() {
 		this.handler.listen();
+		this.numericCannotkickglobopsHandler.listen();
 	}
 }

--- a/apps/flex-web-app/src/modules/kick/socket.d.ts
+++ b/apps/flex-web-app/src/modules/kick/socket.d.ts
@@ -27,3 +27,10 @@ declare interface Commands {
 declare interface CommandResponsesFromServer {
 	KICK: KickDataResponse;
 }
+
+declare interface ErrorReplies {
+	ERR_CANNOTKICKGLOBOPS: {
+		channel: string;
+		nick: string;
+	};
+}

--- a/config/flex/flex.example.yml
+++ b/config/flex/flex.example.yml
@@ -1,16 +1,18 @@
+# Les champs en commentaires ne sont pas obligatoires.
+
 cors:
-  preset: "permissive"
+  preset: permissive
 
 network:
-  name: "Nom d'example"
+  name: Nom d'example
 
 admin:
   name: "John Doe"
-  email: "johndoe@example.org"
-  nick: "JohnDoe"
+  email: johndoe@example.org
+  nick: JohnDoe
 
 server:
-  name: "chat.example.org"
+  name: chat.example.org
 
   #
   # Mot de passe
@@ -25,3 +27,13 @@ server:
   # Date de création du serveur.
   #
   #created_at: 1635185135
+
+operator:
+  auto_join: ["#headquarter", "#staff"]
+
+operators:
+  - identifier: JohnDoe
+    password: "$argon2id..."
+    type: GlobalOperator #| LocalOperator
+    #vhost: example.org/johndoe
+    #flags: [NoKick]

--- a/www/flex-ws-server/config/flex.rs
+++ b/www/flex-ws-server/config/flex.rs
@@ -8,6 +8,8 @@
 // ┃  file, You can obtain one at https://mozilla.org/MPL/2.0/.                ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
+use std::collections::HashSet;
+
 use flex_web_framework::types::{email, secret};
 use flex_web_framework::FeatureConfig;
 
@@ -105,6 +107,9 @@ pub struct flex_config_operator_auth
 	/// Hôte virtuel.
 	#[serde(rename = "vhost")]
 	pub virtual_host: Option<String>,
+	/// Drapeau par défaut à appliquer automatiquement.
+	#[serde(default)]
+	pub flags: HashSet<flex_config_operator_flags>,
 }
 
 #[derive(Debug)]
@@ -116,6 +121,16 @@ pub enum flex_config_operator_type
 	LocalOperator,
 	/// Opérateur Global
 	GlobalOperator,
+}
+
+#[derive(Debug)]
+#[derive(Copy, Clone)]
+#[derive(serde::Deserialize, serde::Serialize)]
+#[derive(PartialEq, Eq, Hash)]
+pub enum flex_config_operator_flags
+{
+	/// Opérateur non kickable.
+	NoKick,
 }
 
 // -------------- //

--- a/www/flex-ws-server/src/chat/components/client/mod.rs
+++ b/www/flex-ws-server/src/chat/components/client/mod.rs
@@ -162,15 +162,20 @@ impl Client
 	}
 
 	/// Marque le client comme étant un opérateur.
-	pub fn marks_client_as_operator(&mut self, oper_type: flex::flex_config_operator_type)
+	pub fn marks_client_as_operator(&mut self, oper: &flex::flex_config_operator_auth)
 	{
 		self.user.set_flag(
-			ApplyMode::new(match oper_type {
+			ApplyMode::new(match oper.oper_type {
 				| flex::flex_config_operator_type::GlobalOperator => super::Flag::GlobalOperator,
 				| flex::flex_config_operator_type::LocalOperator => super::Flag::LocalOperator,
 			})
 			.with_update_by(&self.user().nickname),
-		)
+		);
+		for flag in oper.flags.iter() {
+			self.user.set_flag(ApplyMode::new(match flag {
+				| flex::flex_config_operator_flags::NoKick => super::Flag::NoKick,
+			}));
+		}
 	}
 
 	/// Attribution d'un nouvel ID de Socket.

--- a/www/flex-ws-server/src/chat/components/client/socket.rs
+++ b/www/flex-ws-server/src/chat/components/client/socket.rs
@@ -756,6 +756,22 @@ impl<'a> Socket<'a>
 	}
 
 	/// Émet au client l'erreur
+	/// [crate::src::chat::replies::ErrCannot].
+	pub fn send_err_cannotkickglobops(&self, channel_name: &str, nickname: &str)
+	{
+		use crate::src::chat::replies::ErrCannotkickglobopsError;
+
+		let origin = Origin::from(self.client());
+		let err_cannotsendtochan = ErrCannotkickglobopsError {
+			channel: channel_name,
+			nick: nickname,
+			origin: &origin,
+			tags: ErrCannotkickglobopsError::default_tags(),
+		};
+		self.emit(err_cannotsendtochan.name(), err_cannotsendtochan);
+	}
+
+	/// Émet au client l'erreur
 	/// [crate::src::chat::replies::ErrCannotsendtochanError].
 	pub fn send_err_cannotsendtochan(&self, channel_name: &str)
 	{

--- a/www/flex-ws-server/src/chat/components/user/flag.rs
+++ b/www/flex-ws-server/src/chat/components/user/flag.rs
@@ -37,12 +37,13 @@ pub const USER_FLAG_GLOBAL_OPERATOR: char = 'o';
 /// se "dé-op" lui-même (en utilisant '`-o`' ou '`-O`').
 pub const USER_FLAG_LOCAL_OPERATOR: char = 'O';
 
-/// Drapeau '`q`': utilisateur marqué comme unkickable sur les salons quelques
-/// soient le niveau d'accès des autres membres.
+/// Drapeau '`q`': utilisateur marqué comme non sanctionable d'un KICK sur les
+/// salons quels que soient le niveau d'accès des autres membres.
 ///
 /// Si un utilisateur tente d'appliquer ce drapeau, la tentative devrait être
 /// ignorée. Seuls les opérateurs globaux ont droit d'appliquer ce drapeau à
-/// eux-même.
+/// eux-même; les opérateurs globaux NE PEUVENT PAS appliquer ce drapeau aux
+/// autres utilisateurs.
 pub const USER_FLAG_NOKICK: char = 'q';
 
 // ----------- //

--- a/www/flex-ws-server/src/chat/components/user/flag.rs
+++ b/www/flex-ws-server/src/chat/components/user/flag.rs
@@ -37,6 +37,14 @@ pub const USER_FLAG_GLOBAL_OPERATOR: char = 'o';
 /// se "dé-op" lui-même (en utilisant '`-o`' ou '`-O`').
 pub const USER_FLAG_LOCAL_OPERATOR: char = 'O';
 
+/// Drapeau '`q`': utilisateur marqué comme unkickable sur les salons quelques
+/// soient le niveau d'accès des autres membres.
+///
+/// Si un utilisateur tente d'appliquer ce drapeau, la tentative devrait être
+/// ignorée. Seuls les opérateurs globaux ont droit d'appliquer ce drapeau à
+/// eux-même.
+pub const USER_FLAG_NOKICK: char = 'q';
+
 // ----------- //
 // Énumération //
 // ----------- //
@@ -58,6 +66,9 @@ pub enum Flag
 	GlobalOperator,
 	/// Opérateur local.
 	LocalOperator,
+
+	/// Opérateur non kickable.
+	NoKick,
 }
 
 // -------------- //
@@ -69,9 +80,10 @@ impl Flag
 	pub fn letter(&self) -> char
 	{
 		match self {
-			| Flag::Away(_) => USER_FLAG_AWAY,
-			| Flag::GlobalOperator => USER_FLAG_GLOBAL_OPERATOR,
-			| Flag::LocalOperator => USER_FLAG_LOCAL_OPERATOR,
+			| Self::Away(_) => USER_FLAG_AWAY,
+			| Self::GlobalOperator => USER_FLAG_GLOBAL_OPERATOR,
+			| Self::LocalOperator => USER_FLAG_LOCAL_OPERATOR,
+			| Self::NoKick => USER_FLAG_NOKICK,
 		}
 	}
 }

--- a/www/flex-ws-server/src/chat/components/user/mod.rs
+++ b/www/flex-ws-server/src/chat/components/user/mod.rs
@@ -100,9 +100,24 @@ impl User
 			.unwrap_or_default()
 	}
 
+	/// Les drapeaux utilisateurs.
 	pub fn flags(&self) -> impl Iterator<Item = (char, ApplyMode<Flag>)> + '_
 	{
 		self.flags.iter().map(|flag| (flag.letter(), flag.clone()))
+	}
+
+	/// Vérifie que l'utilisateur a comme drapeau, le drapeau q (nokick).
+	pub fn has_nokick_flag(&self) -> bool
+	{
+		self.flags.iter().any(|flag| {
+			matches!(
+				flag,
+				ApplyMode {
+					flag: Flag::NoKick,
+					..
+				}
+			)
+		})
 	}
 
 	/// Vérifie si le pseudonyme donné est le même que celui sauvegardé dans

--- a/www/flex-ws-server/src/chat/features/kick/response.rs
+++ b/www/flex-ws-server/src/chat/features/kick/response.rs
@@ -8,8 +8,8 @@
 // ┃  file, You can obtain one at https://mozilla.org/MPL/2.0/.                ┃
 // ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
-use crate::command_response;
 use crate::src::chat::components::Origin;
+use crate::{command_response, error_replies};
 
 command_response! {
 	struct KICK
@@ -21,4 +21,11 @@ command_response! {
 		/// La victime.
 		knick: &'a Origin,
 	}
+}
+
+error_replies! {
+	/// Renvoyé pour indiquer l'échec d'une tentative de sanction KICK sur un
+	/// utilisateur (opérateur global) ayant le drapeau utilisateur +q.
+	| 480 <-> ERR_CANNOTKICKGLOBOPS { channel: str, nick: str }
+		=> "{channel} {nick} :Vous n'avez pas le droit de sanctionner d'un KICK cet utilisateur (protégé par le drapeau +q)"
 }

--- a/www/flex-ws-server/src/chat/features/oper/handler.rs
+++ b/www/flex-ws-server/src/chat/features/oper/handler.rs
@@ -67,11 +67,7 @@ impl OperHandler
 			return;
 		}
 
-		app.marks_client_as_operator(
-			&mut client_socket,
-			operator.virtual_host.as_deref(),
-			operator.oper_type,
-		);
+		app.marks_client_as_operator(&mut client_socket, &operator);
 
 		for channel_name in config.operator.auto_join.iter() {
 			app.join_or_create_oper_channel(&client_socket, channel_name);

--- a/www/flex-ws-server/src/chat/mod.rs
+++ b/www/flex-ws-server/src/chat/mod.rs
@@ -168,6 +168,7 @@ mod replies
 	}
 
 	pub use super::features::{
+		ErrCannotkickglobopsError,
 		ErrNooperhostError,
 		ErrOperonlyError,
 		ErrPasswdmismatchError,

--- a/www/flex-ws-server/src/chat/sessions/client.rs
+++ b/www/flex-ws-server/src/chat/sessions/client.rs
@@ -257,22 +257,19 @@ impl ChatApplication
 	pub fn marks_client_as_operator(
 		&self,
 		client_socket: &mut client::Socket,
-		oper_vhost: Option<&str>,
-		oper_type: flex::flex_config_operator_type,
+		oper: &flex::flex_config_operator_auth,
 	)
 	{
 		self.clients
-			.marks_client_as_operator(client_socket.cid(), oper_vhost, oper_type);
+			.marks_client_as_operator(client_socket.cid(), oper);
 
-		if let Some(vhost) = oper_vhost {
+		if let Some(vhost) = oper.virtual_host.as_deref() {
 			client_socket.user_mut().set_vhost(vhost);
 		}
 
-		client_socket
-			.client_mut()
-			.marks_client_as_operator(oper_type);
+		client_socket.client_mut().marks_client_as_operator(oper);
 
-		let flag_oper = match oper_type {
+		let flag_oper = match oper.oper_type {
 			| flex::flex_config_operator_type::LocalOperator => {
 				components::user::Flag::LocalOperator
 			}
@@ -459,16 +456,15 @@ impl ClientsSession
 	pub fn marks_client_as_operator(
 		&self,
 		client_id: &client::ClientID,
-		oper_vhost: Option<&str>,
-		oper_type: flex::flex_config_operator_type,
+		oper: &flex::flex_config_operator_auth,
 	)
 	{
 		let Some(mut client) = self.get_mut(client_id) else {
 			return;
 		};
 
-		client.marks_client_as_operator(oper_type);
-		if let Some(vhost) = oper_vhost {
+		client.marks_client_as_operator(oper);
+		if let Some(vhost) = oper.virtual_host.as_deref() {
 			client.set_vhost(vhost);
 		}
 	}


### PR DESCRIPTION
Ce drapeau permet aux opérateurs globaux d'être protégé d'une sanction de KICK dans tous les salons, quels que soient les niveaux d'accès des opérateurs des salons.