### PR TITLE
Tests: Quitter un salon

### DIFF
--- a/apps/flex-web-app/package.json
+++ b/apps/flex-web-app/package.json
@@ -9,7 +9,7 @@
 		"build": "vue-tsc -p ./config/tsconfig.app.json && vite build --config config/vite.config.ts",
 		"lint": "vue-tsc",
 		"preview": "vite preview --config config/vite.config.ts",
-		"test:e2e": "playwright test -c ./config/playwright.config.ts",
+		"test:e2e": "playwright test -x -c ./config/playwright.config.ts",
 		"test:e2e:report": "playwright show-report tests/e2e/report"
 	},
 	"dependencies": {

--- a/apps/flex-web-app/sys/navigation-room/NavigationRoom.vue
+++ b/apps/flex-web-app/sys/navigation-room/NavigationRoom.vue
@@ -33,6 +33,7 @@ const totalUnread = computeTotalUnread(props);
 			'is-active': active,
 			'is-highlight': highlight,
 		}"
+		:data-room="name"
 		@click="openRoomHandler"
 		@keypress.space="openRoomHandler"
 		@keypress.enter="openRoomHandler"

--- a/apps/flex-web-app/tests/e2e/join_channel.spec.ts
+++ b/apps/flex-web-app/tests/e2e/join_channel.spec.ts
@@ -83,7 +83,7 @@ test("Rejoindre un salon avec une clé via la commande /JOIN", async ({
 	);
 });
 
-test.only("Rejoindre un salon via la boite de dialogue (de la vue ChannelList)", async ({
+test("Rejoindre un salon via la boite de dialogue (de la vue ChannelList)", async ({
 	page,
 }) => {
 	await connectChat({ page });

--- a/apps/flex-web-app/tests/e2e/part_channel.spec.ts
+++ b/apps/flex-web-app/tests/e2e/part_channel.spec.ts
@@ -1,0 +1,103 @@
+// ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+// ┃ Copyright: (c) 2024, Mike 'PhiSyX' S. (https://github.com/PhiSyX)         ┃
+// ┃ SPDX-License-Identifier: MPL-2.0                                          ┃
+// ┃ ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌ ┃
+// ┃                                                                           ┃
+// ┃  This Source Code Form is subject to the terms of the Mozilla Public      ┃
+// ┃  License, v. 2.0. If a copy of the MPL was not distributed with this      ┃
+// ┃  file, You can obtain one at https://mozilla.org/MPL/2.0/.                ┃
+// ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
+
+import { expect, test, type Page, Locator } from "@playwright/test";
+
+// See here how to get started:
+// https://playwright.dev/docs/intro
+
+async function connectChat({
+	page,
+	channels = "",
+}: { page: Page; channels?: string }) {
+	// biome-ignore lint/style/useTemplate: Pas envie.
+	const nickname = "x" + (Math.random() + 1).toString(36).slice(2) + "x";
+
+	await page.goto("/");
+	await page.locator("#nickname").fill(nickname);
+	await page.locator("#channels").fill(channels);
+
+	const $btnLogin = page.locator('#chat-login-view button[type="submit"]');
+	await $btnLogin.click();
+}
+
+async function partChannel(
+	{ page, channel }: { page: Page; channel: string },
+	testFn: (_: {
+		$navRooms: Locator;
+		$navRoomsItems: Locator;
+		$channelRoom: Locator;
+	}) => Promise<void>,
+) {
+	await connectChat({ page, channels: channel });
+
+	const $navRooms = page.locator(".navigation-area .navigation-server ul");
+	const $navRoomsItems = $navRooms.locator(" li");
+	await expect($navRoomsItems).toHaveCount(1);
+
+	const $channelRoom = page.locator(`.room\\/channel[data-room="${channel}"]`);
+
+	await testFn({
+		$navRooms,
+		$navRoomsItems,
+		$channelRoom,
+	});
+
+	await expect($navRoomsItems).toHaveCount(0);
+	await expect($navRoomsItems).not.toHaveCount(1);
+}
+
+test("Partir d'un salon via la commande /PART", async ({ page }) => {
+	const channelToPart = "#test-part-command";
+	await partChannel(
+		{ page, channel: channelToPart },
+		async ({ $channelRoom }) => {
+			const $form = $channelRoom.locator(
+				`form[action='/privmsg/${encodeURIComponent(channelToPart)}']`,
+			);
+
+			const $input = $form.locator("input[type='text']");
+			$input.fill(`/part ${channelToPart}`);
+
+			const $btnSubmit = $form.locator("button[type='submit']");
+			await $btnSubmit.click();
+		},
+	);
+});
+
+test("Partir d'un salon via le bouton de fermeture du la navigation", async ({
+	page,
+}) => {
+	const channelToPart = "#test-part-channel";
+	await partChannel({ page, channel: channelToPart }, async ({ $navRooms }) => {
+		const $navChannelRoom = $navRooms.locator(
+			`li[data-room="${channelToPart}"]`,
+		);
+		await $navChannelRoom.click();
+
+		const $btnCloseChannelRoom = $navChannelRoom.locator(".close");
+		await $btnCloseChannelRoom.click();
+	});
+});
+
+test("Partir d'un salon via le bouton de fermeture du salon", async ({
+	page,
+}) => {
+	const channelToPart = "#test-part-channel";
+	await partChannel(
+		{ page, channel: channelToPart },
+		async ({ $channelRoom }) => {
+			const $topicActions = $channelRoom.locator(".room\\/topic\\:action");
+
+			const $btnCloseChannelRoom = $topicActions.locator(".close");
+			await $btnCloseChannelRoom.click();
+		},
+	);
+});


### PR DESCRIPTION
- chore(web): initialisation des tests e2e
- tests(web): tests de la page de login
- tests(web): rejoindre un salon
- tests(web): quitter un salon (self)
- tests(web): quitter un salon (user)
